### PR TITLE
Parse info

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
       "redis:6379"
     ],
     "metrics": [
-      "used_memory"
+      "used_memory",
+      "mem_fragmentation_ratio",
+      "db0.keys"
     ]
 }

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	separator         = ":"
+	keyspaceSeparator = ","
+	equal             = "="
+)
+
+// Parse reads redis INFO reply and parse it into map[string]float64.
+// Only metrics with valid float64 values are eligible to store into result map.
+// Sections like "Keyspace" are handled different than others once their values
+// have slightly different format.
+func Parse(reply []byte) map[string]float64 {
+	statistics := make(map[string]float64)
+
+	reader := bytes.NewReader(reply)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, separator) {
+			line = strings.TrimSpace(line)
+			parts := strings.Split(line, separator)
+			key := parts[0]
+			value := parts[1]
+
+			// Parse and store only valid float64 values
+			if value, err := strconv.ParseFloat(value, 64); err == nil {
+				statistics[key] = value
+				continue
+			}
+
+			// Check if value is formatted as "keys=0,expires=0,avg_ttl=0"
+			if strings.Contains(value, keyspaceSeparator) {
+				// Split value into string slice ["keys=0", "expires=0", "avg_ttl=0"]
+				for _, value := range strings.Split(value, keyspaceSeparator) {
+					// Check if each slice value is formatted as "keys=0"
+					if strings.Contains(value, equal) {
+						// Split value into string slice ["keys", "0"]
+						parts := strings.Split(value, equal)
+						// Parse and store only valid float64 values
+						if value, err := strconv.ParseFloat(parts[1], 64); err == nil {
+							// Create key based on previous key and part of each
+							// slice. Example:
+							// Source: db0:keys=0,expires=0,avg_ttl=0
+							// Become:	db0.keys
+							// 			db0.expires
+							//			db0.avg_ttl
+							composedKey := fmt.Sprintf("%s.%s", key, parts[0])
+							statistics[composedKey] = value
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return statistics
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,37 @@
+package main_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/daime/redis-metrics"
+)
+
+func TestParse(t *testing.T) {
+	info := `
+		# Memory
+		used_memory:1000000
+		used_memory_human:1.0M
+		shouldNotBeParsed
+
+		# Keyspace
+		db0:keys=123,expires=37,avg_ttl=56789
+		db1:keys=456,expires=48,avg_ttl=67890
+	`
+
+	lines := main.Parse([]byte(info))
+
+	expected := map[string]float64{
+		"used_memory": 1000000,
+		"db0.keys":    123,
+		"db0.expires": 37,
+		"db0.avg_ttl": 56789,
+		"db1.keys":    456,
+		"db1.expires": 48,
+		"db1.avg_ttl": 67890,
+	}
+
+	if !reflect.DeepEqual(expected, lines) {
+		t.Errorf("Expected %v, but got %v", expected, lines)
+	}
+}


### PR DESCRIPTION
This PR parse redis INFO reply into a map[string]float64. Sections like Keyspace are handled as a special cases once their format are slightly different than others.

From: http://redis.io/commands/INFO

```
The keyspace section provides statistics on the main dictionary of each database. The statistics are the number of keys, and the number of keys with an expiration.
For each database, the following line is added:
dbXXX: keys=XXX,expires=XXX
```
